### PR TITLE
service: Drop ExecRestart for systemd service file

### DIFF
--- a/nft-blackhole.service
+++ b/nft-blackhole.service
@@ -9,7 +9,6 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/nft-blackhole.py start
 ExecStop=/usr/bin/nft-blackhole.py stop
 
-ExecRestart=/usr/bin/nft-blackhole.py restart
 ExecReload=/usr/bin/nft-blackhole.py reload
 
 User=root


### PR DESCRIPTION
Hi,

Stumbled on this great script and wanted to get it in action and stumbled on an issue with the systemd service when running `systemctl daemon-reload`:

```
Sep 07 23:06:21 host systemd[1]: /usr/lib/systemd/system/nft-blackhole.service:12: Unknown key name 'ExecRestart' in section 'Service', ignoring.
```

Running on Arch Linux:
```
$ systemctl --version
systemd 246 (246.4-1-arch)
```

I believe `systemctl restart ...` is implemented by `systemd` stopping and then starting the service on it's own.  Removing or commenting out the the `ExecRestart` fixes the warning.

[Documentation for `systemd.service`](https://www.freedesktop.org/software/systemd/man/systemd.service.html)