### PR TITLE
systemd: Add systemd timer and service

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ For example:
     /usr/share/nft-blackhole/nft-blackhole.template
     /etc/nft-blackhole.conf
     /usr/lib/systemd/system/nft-blackhole.service
+    /usr/lib/systemd/system/nft-blackhole-reload.service
+    /usr/lib/systemd/system/nft-blackhole-reload.timer
 
 ## Configuration
 #### Set the configuration in a file
@@ -81,13 +83,19 @@ For example:
 ### List table and sets for blackhole
     nft list table inet blackhole
 ### Refresh lists
+#### Manual
 
     /usr/bin/nft-blackhole.py reload
     systemctl reload nft-blackhole.service
-    
-or add to root crontab e.g.
+
+#### Crontab
     
     0 */6 * * * systemctl reload nft-blackhole.service
+
+#### Systemd Timer
+
+    systemctl enable --now nft-blackhole-reload.service
+    systemctl list-timers
 
 ## Credits
 [country-ip-blocks](https://github.com/herrbischoff/country-ip-blocks) - CIDR country-level IP lists,

--- a/nft-blackhole-reload.service
+++ b/nft-blackhole-reload.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Update nft blackhole table
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/nft-blackhole.py reload
+
+User=root

--- a/nft-blackhole-reload.timer
+++ b/nft-blackhole-reload.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description="Update blackhole lists"
+
+[Timer]
+OnBootSec=15min
+OnUnitActiveSec=6h
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This simplifies the reloading of lists using `systemd`'s timer mechanism which replaces cron in many cases.

This maintains the 6 hour interval from the cron example.

Update `README` to document.