### PR TITLE
Fix YAML parsing Norway as False

### DIFF
--- a/nft-blackhole.py
+++ b/nft-blackhole.py
@@ -31,6 +31,11 @@ WHITELIST = config['WHITELIST']
 BLACKLIST = config['BLACKLIST']
 COUNTRY_LIST = config['COUNTRY_LIST']
 
+# Correct incorrect YAML parsing of NO (Norway)
+# It should be the string 'no', but YAML interprets it as False
+while False in COUNTRY_LIST:
+    COUNTRY_LIST[COUNTRY_LIST.index(False)] = 'no'
+
 SET_TEMPLATE = ('table inet blackhole {\n\tset ${set_name} {\n\t\ttype ${ip_ver}_addr\n'
                 '\t\tflags interval\n\t\tauto-merge\n\t\telements = { ${ip_list} }\n\t}\n}')
 


### PR DESCRIPTION
If the user writes `no` in the country list, they mean Norway, not the opposite of "yes".
Unfortunately, YAML interprets this as `False`, causing exceptions later when the code expects a string.
This only happens if `no` is unquoted, but none of the example countries have quotes, and there's no mention of YAML in the default config, so it's likely users will discover this behavior the hard way.

This PR's fix replaces any `False` value in the `COUNTRY_LIST` with the string `'no'`.