### PR TITLE
Feature: Optionally apply blacklist for Forwards

### DIFF
--- a/nft-blackhole.conf
+++ b/nft-blackhole.conf
@@ -15,6 +15,8 @@ BLOCK_POLICY: drop
 # Connections to blocked countries will still be possible.
 BLOCK_OUTPUT: off
 
+# Block forwarded connections from blacklisted ips: 'on' or 'off', default: 'off'
+BLOCK_FORWARD: off
 
 # Whitelist: IP or Network adresses
 WHITELIST:

--- a/nft-blackhole.py
+++ b/nft-blackhole.py
@@ -54,8 +54,8 @@ FORWARD_TEMPLATE = ('\tchain forward {\n\t\ttype filter hook forward priority -1
                    '\t\tip6 saddr @blacklist-v6 counter ${block_policy}\n'
                    '\t\t${country_ex_ports_rule}'
                    '\t\tip saddr @country-v4 counter ${country_policy}\n'
-                   '\t\tip6 saddr @contry-v6 counter ${country_policy}\n'
-                   '\t\tcounter\t}').expandtabs() 
+                   '\t\tip6 saddr @country-v6 counter ${country_policy}\n'
+                   '\t\tcounter\n\t}').expandtabs() 
 
 OUTPUT_TEMPLATE = ('\tchain output {\n\t\ttype filter hook output priority -1; policy accept;\n'
                    '\t\tip daddr @whitelist-v4 counter accept\n'

--- a/nft-blackhole.py
+++ b/nft-blackhole.py
@@ -34,6 +34,7 @@ WHITELIST = config['WHITELIST']
 BLACKLIST = config['BLACKLIST']
 COUNTRY_LIST = config['COUNTRY_LIST']
 BLOCK_OUTPUT = config['BLOCK_OUTPUT']
+BLOCK_FORWARD = config['BLOCK_FORWARD']
 
 
 # Correct incorrect YAML parsing of NO (Norway)
@@ -44,6 +45,12 @@ while False in COUNTRY_LIST:
 
 SET_TEMPLATE = ('table inet blackhole {\n\tset ${set_name} {\n\t\ttype ${ip_ver}_addr\n'
                 '\t\tflags interval\n\t\tauto-merge\n\t\telements = { ${ip_list} }\n\t}\n}').expandtabs()
+
+FORWARD_TEMPLATE = ('\tchain forward {\n\t\ttype filter hook forward priority -1; policy accept;\n'
+                   '\t\tip saddr @whitelist-v4 counter accept\n'
+                   '\t\tip6 saddr @whitelist-v6 counter accept\n'
+                   '\t\tip saddr @blacklist-v4 counter ${block_policy}\n'
+                   '\t\tip6 saddr @blacklist-v6 counter ${block_policy}\n\t}').expandtabs() 
 
 OUTPUT_TEMPLATE = ('\tchain output {\n\t\ttype filter hook output priority -1; policy accept;\n'
                    '\t\tip daddr @whitelist-v4 counter accept\n'
@@ -82,6 +89,11 @@ if BLOCK_OUTPUT:
 else:
     chain_output = ''
 
+if BLOCK_FORWARD:
+    chain_forward = Template(FORWARD_TEMPLATE).substitute(block_policy=block_policy)
+else:
+    chain_forward = ''
+
 # Setting urllib
 ctx = ssl.create_default_context()
 IGNORE_CERTIFICATE = False
@@ -109,7 +121,8 @@ def start():
                                                  block_policy=block_policy,
                                                  country_ex_ports_rule=country_ex_ports_rule,
                                                  country_policy=country_policy,
-                                                 chain_output=chain_output)
+                                                 chain_output=chain_output,
+                                                 chain_forward=chain_forward,)
     with open(tmp_file.name, 'w') as f:
         f.write(nft_conf)
     run(['nft', '-f', tmp_file.name], check=True)

--- a/nft-blackhole.py
+++ b/nft-blackhole.py
@@ -47,6 +47,7 @@ SET_TEMPLATE = ('table inet blackhole {\n\tset ${set_name} {\n\t\ttype ${ip_ver}
                 '\t\tflags interval\n\t\tauto-merge\n\t\telements = { ${ip_list} }\n\t}\n}').expandtabs()
 
 FORWARD_TEMPLATE = ('\tchain forward {\n\t\ttype filter hook forward priority -1; policy accept;\n'
+                   '\t\tct state established,related accept\n'
                    '\t\tip saddr @whitelist-v4 counter accept\n'
                    '\t\tip6 saddr @whitelist-v6 counter accept\n'
                    '\t\tip saddr @blacklist-v4 counter ${block_policy}\n'

--- a/nft-blackhole.py
+++ b/nft-blackhole.py
@@ -51,7 +51,11 @@ FORWARD_TEMPLATE = ('\tchain forward {\n\t\ttype filter hook forward priority -1
                    '\t\tip saddr @whitelist-v4 counter accept\n'
                    '\t\tip6 saddr @whitelist-v6 counter accept\n'
                    '\t\tip saddr @blacklist-v4 counter ${block_policy}\n'
-                   '\t\tip6 saddr @blacklist-v6 counter ${block_policy}\n\t}').expandtabs() 
+                   '\t\tip6 saddr @blacklist-v6 counter ${block_policy}\n'
+                   '\t\t${country_ex_ports_rule}'
+                   '\t\tip saddr @country-v4 counter ${country_policy}\n'
+                   '\t\tip6 saddr @contry-v6 counter ${country_policy}\n'
+                   '\t\tcounter\t}').expandtabs() 
 
 OUTPUT_TEMPLATE = ('\tchain output {\n\t\ttype filter hook output priority -1; policy accept;\n'
                    '\t\tip daddr @whitelist-v4 counter accept\n'
@@ -91,7 +95,9 @@ else:
     chain_output = ''
 
 if BLOCK_FORWARD:
-    chain_forward = Template(FORWARD_TEMPLATE).substitute(block_policy=block_policy)
+    chain_forward = Template(FORWARD_TEMPLATE).substitute(block_policy=block_policy,
+                                                          country_policy=country_policy,
+                                                          country_ex_ports_rule=country_ex_ports_rule)
 else:
     chain_forward = ''
 

--- a/nft-blackhole.template
+++ b/nft-blackhole.template
@@ -50,4 +50,6 @@ table inet blackhole {
         }
 
         ${chain_output}
+
+        ${chain_forward}
 }


### PR DESCRIPTION
Thanks for this nice project!

This aims/proposes to add the ability to also optionally chain the blocklist into the forward hook, so that forwarded packets are also dropped when they origin from a 'bad' ip.

I applied this to the debian-10 branch as it is the one I use, and it seemed to have more recent changes

(I don't know if this is useful for others as well, but I needed it in my use case anyway.)

I could positively test that the forward chain is not added when the config 'BLOCK_FORWARD' is 'off' and that forwarded packets from blacklisted ips are discarded when it is enabled.

I did not verify whether the country block settings (and specific port overwrites) also work for the forward chain (but I would assume they do)